### PR TITLE
modified hamburger icon and top banner message

### DIFF
--- a/components/SideDrawer.jsx
+++ b/components/SideDrawer.jsx
@@ -11,6 +11,7 @@ import ContactUsButton from "./ContactUsButton";
 
 import { useTheme, useMediaQuery } from "@mui/material";
 
+
 const SideDrawer = ({ navLinks }) => {
   const [state, setState] = useState({
     right: false,
@@ -336,7 +337,7 @@ const SideDrawer = ({ navLinks }) => {
 
   return (
     <>
-      <IconButton
+      <IconButton className="hamburger-btn"
         edge="start"
         aria-label="menu"
         onClick={toggleDrawer("right", true)}

--- a/components/TopBanner.jsx
+++ b/components/TopBanner.jsx
@@ -45,20 +45,17 @@ const TopBanner = (props) => {
       >
         { props.isMobile && props.second == "Low Start-up Cost, Big Numbers in Return" ?
         <Typography
-          color={"secondary.main"}
-          variant={
-            props.isMobile ? (props.title == "Home" ? "h6" : "h2") : "h2"
-          }
+          color="secondary.main"
+          variant={ props.title == "Home" ? "h6" : "h2" }
           align="right"
+          sx={{lineHeight: 1.0}}
         >
           Low Start-up Cost, <br />Big Numbers in Return
         </Typography>
         :
         <Typography
-        color={"secondary.main"}
-        variant={
-          props.isMobile ? (props.title == "Home" ? "h6" : "h2") : "h2"
-        }
+        color="secondary.main"
+        variant="h2"
         align="right"
         >
           {props.second}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -71,3 +71,7 @@ body {
 .TextField-without-border-radius fieldset {
   border-radius: 0;
 }
+
+.hamburger-btn {
+  transform: scale(1.7);
+}


### PR DESCRIPTION
the hamburger icon size is changed to bigger and the top-banner message gap in mobile is changed to smaller
top-banner message : "Low Start-up Cost, Big Numbers in Return"


before
![image](https://user-images.githubusercontent.com/106633547/172962755-3effb717-7b6d-44a4-9050-bf671f3a77d4.png)


after
![image](https://user-images.githubusercontent.com/106633547/172962784-e516e270-b535-442e-acd9-24d48b00b399.png)
