### PR TITLE
modifeid imported wrong path and moved aboutus image to center in mobile

### DIFF
--- a/components/aboutus/FranchiseTimeline.jsx
+++ b/components/aboutus/FranchiseTimeline.jsx
@@ -3,7 +3,7 @@ import Timeline from "@mui/lab/Timeline";
 import FranchiseTimelineItem from "./FranchiseTimelineItem";
 import { timelineData } from "data/timeline";
 import Image from 'next/image';
-import Container from '@mui/material/Container';
+import { Container, Grid } from '@mui/material';
 
 const FranchiseTimeline = ({isMobile}) => {
   return (
@@ -14,13 +14,15 @@ const FranchiseTimeline = ({isMobile}) => {
             paddingTop: "48px"
           }}
           >
+          <Grid align="center" justifyContent="center">
           <Image
               src="/aboutpage/aboutimg.jpg"
               alt="Cooking"
               width="376px"
               height="268px"
           />
-        </Container>        
+          </Grid>
+        </Container>
       )}
       <Timeline
         sx={{

--- a/components/contactus/ContactUsBanner.jsx
+++ b/components/contactus/ContactUsBanner.jsx
@@ -1,5 +1,5 @@
 import { Button, Grid, Typography } from "@mui/material";
-import ContactUsButton from "../components/contactus/ContactUsButton";
+import ContactUsButton from "./ContactUsButton";
 
 const ContactUsBanner = (props) => {
     return (


### PR DESCRIPTION
1. ContactUsBanner.jsx에 ContactUsButton Path 에러해결
2. About 페이지에서 모바일일때 보이는 이미지 위치를 왼쪽 -> 가운데로 보이게 수정
![image](https://user-images.githubusercontent.com/106633547/174008893-04e676c7-ff9e-4db4-a9bb-b1208164eade.png)
