### PR TITLE
edited text size and color in main, about, menu pages

### DIFF
--- a/components/About.jsx
+++ b/components/About.jsx
@@ -8,8 +8,8 @@ import FranchiseTimeline from './aboutus/FranchiseTimeline';
 const AboutPage = ({isMobile}) => {
 
   return (
-    <Container 
-  
+    <Container
+
       justify="center"
       direction="column"
       justifycontent="center"
@@ -21,7 +21,7 @@ const AboutPage = ({isMobile}) => {
         justify="center"
         flexDirection="column"
         justifycontent="center"
-        alignItems="center" 
+        alignItems="center"
         sx={{ mb: 1, mt: 1}}
       >
         <Grid
@@ -46,7 +46,7 @@ const AboutPage = ({isMobile}) => {
         </Typography>
         <Typography
           color="text"
-          variant= {isMobile ? 'h5' : 'h3'}
+          variant= {isMobile ? 'body2' : 'body1'}
           align="center"
           fontWeight={"fontWeightBold"}
           fontFamily={"Nunito"}
@@ -65,15 +65,15 @@ const AboutPage = ({isMobile}) => {
           direction="column"
           justifyContent="center"
           alignitems="left"
-          width={isMobile ? 346 : 596} 
-        > 
-          <Typography 
-            variant={isMobile ? 'body2' : 'body1'} 
-            fontStyle='italic' color="text.main" textAlign="center" pt = {isMobile ? 6 : 8 } 
+          width={isMobile ? 346 : 596}
+        >
+          <Typography
+            variant={isMobile ? 'body2' : 'body1'}
+            fontStyle='italic' color="text.main" textAlign="center" pt = {isMobile ? 6 : 8 }
             paddingTop={isMobile ? 0 : "68px"}>
           “Most people consider sushi to be pricey and not an everyday kind of experience. At Sushi Rollin’, the experience is approachable yet still unique.”
           </Typography>
-          <Typography variant='body1' color="333333" 
+          <Typography variant='body1' color="333333"
             textAlign="center"
             pt = {isMobile ? 0 : 2 }
             py = {isMobile ? 2 : 0 }
@@ -87,10 +87,10 @@ const AboutPage = ({isMobile}) => {
             <Button> Franchise Opportunity</Button>
           </MuiNextLink>
           <MuiNextLink href="/menu" underline="none" sx={{ mt: 4, mb: 5 }}>
-            <Button 
+            <Button
             style={{maxWidth: isMobile ? '230px' : '263px', minWidth: isMobile ? '230px' :'263px'}}
             variant="outlined" // black outline
-            sx={{ 
+            sx={{
               backgroundColor: "white",
               borderColor: "primary.main",
               color: "primary.main",

--- a/components/OrderBanner.jsx
+++ b/components/OrderBanner.jsx
@@ -23,7 +23,7 @@ const OrderBanner = (props) => {
       <Grid item xs={12}>
         <div className="display-linebreak">
           <Typography
-            color="text"
+            color={props.text=="Find Us Here" ? "secondary.main" : "text"}
             variant={props.isMobile ? "h3" : "h2"}
             align="center"
           >

--- a/components/home/SectionAbout.jsx
+++ b/components/home/SectionAbout.jsx
@@ -32,11 +32,11 @@ const SectionAbout = ({ isMobile }) => {
         >
           <Typography
             color="text"
-            variant={isMobile ? "h3" : "h2"}
+            variant={isMobile ? "h4" : "h3"}
             textAlign={isMobile ? "left" : "center"}
             sx={isMobile ? { my: 2 } : { my: 2, px: 2 }}
           >
-            Started in the middle of pandemic, but we kept rolling with 200% of average annual growth.
+            Started in the middle of pandemic, <br />but we kept rolling with 200% of <br />average annual growth.
           </Typography>
           <MuiNextLink href="/aboutus" underline="none" sx={{ py: 2 }}>
             <Button>About Sushi Rollin’</Button>
@@ -93,11 +93,11 @@ const SectionAbout = ({ isMobile }) => {
         >
           <Typography
             color="text"
-            variant={isMobile ? "h3" : "h2"}
+            variant={isMobile ? "h4" : "h3"}
             textAlign={isMobile ? "left" : "center"}
             sx={isMobile ? { my: 2 } : { my: 2, px: 2 }}
           >
-            Adaptable business model with low cost. Great choice for first-time franchisees.
+            Adaptable business model with low cost. <br />Great choice for first-time franchisees.
           </Typography>
           <MuiNextLink href="/franchise" underline="none" sx={{ py: 2 }}>
             <Button>Franchise Opportunity</Button>

--- a/components/home/SectionMenu.jsx
+++ b/components/home/SectionMenu.jsx
@@ -26,13 +26,13 @@ export default function SectionMenu(props) {
 
         <Grid align="center" >
         { props.isMobile ?
-          <Typography color="text" variant="h5" align="center" mb={3}>
+          <Typography color="text" variant="body2" align="center" mb={3}>
           Asian cuisine has surpassed all other categories for the last 15 years and it continues to grow. We have 60+ rolls & sushi items and 30+ flavorful dishes on the menu.
           </Typography>
         :
-          <Typography color="text" variant="h3" align="center" mb={5}>
-          Asian cuisine has surpassed all other categories for the last 15 years and it continues
-          <br />to grow. We have 60+ rolls & sushi items and 30+ flavorful dishes on the menu.
+          <Typography color="text" variant="body1" align="center" mb={5}>
+          Asian cuisine has surpassed all other categories for the last 15 years and it continues to grow.
+          <br />We have 60+ rolls & sushi items and 30+ flavorful dishes on the menu.
           </Typography>
         }
         </Grid>

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -42,7 +42,7 @@ let theme = createTheme({
       fontWeight: fontBold,
     },
     h6: {
-      fontSize: 12,
+      fontSize: 14,
       fontWeight: fontBold,
     },
     subtitle1: {


### PR DESCRIPTION
상기님 요청
1. Home : 맨 처음 본문 내용 글자크기 작게/unbold, 그외에도  DT -body 1, MOW- Body 2로 통일
2. About: 맨 처음 본문 내용 글자크기 작게/unbold, MOWH6 크기를 12 px 에서 14px로 조정, 그 외 본문 내용 DT-body 1, MOW- body 2로 통일
3. Menu: Mow H6크기 위와 동일하게 변경, 맨 밑에 Find Us Here글자만 산호색으로 변경 (밑에 브랜드 로고들과 너무 헷갈려서요)

![image](https://user-images.githubusercontent.com/106633547/174454640-165c409c-1294-444d-963d-34b16fde5226.png)

![image](https://user-images.githubusercontent.com/106633547/174454649-ff16e35f-067b-4748-b610-5091e3f0d41b.png)

![image](https://user-images.githubusercontent.com/106633547/174454654-7166fec0-cc4f-42a0-8946-d59fc3dee0a5.png)

![image](https://user-images.githubusercontent.com/106633547/174454665-35110efe-44a0-4b69-95d6-b22f44f4ea91.png)
